### PR TITLE
Add CODEOWNERS file to define code ownership

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vanessa-cooper @carl-rattmann


### PR DESCRIPTION
Introduce a CODEOWNERS file to specify code ownership for the repository.